### PR TITLE
No need to use a reserved port, and thus no need for sudo

### DIFF
--- a/runlocally.sh
+++ b/runlocally.sh
@@ -1,2 +1,5 @@
-sudo php -S 127.0.0.1:80
-echo open http://127.0.0.1:80/
+#!/usr/bin/env sh
+
+${BROWSER:-firefox} "http://127.0.0.1:8123/"
+echo "Opening http://127.0.0.1:8123/"
+php -S 127.0.0.1:8123


### PR DESCRIPTION
- No need to use a reserved port, and thus no need for sudo
- I also swapped the two lines, as the "echo .." was never displayed as soon as php was running
- Using $BROWSER environment variable should be cross-platform between Mac OS and GNU/Linux, or at least between different Linux distributions